### PR TITLE
Teachers コントローラーのdestroyの実装・テスト作成

### DIFF
--- a/app/controllers/api/v1/teachers_controller.rb
+++ b/app/controllers/api/v1/teachers_controller.rb
@@ -1,10 +1,41 @@
 class Api::V1::TeachersController < ApplicationController
   before_action :authenticate_user!
   before_action :require_admin_role!
-  before_action :set_school!
+  before_action :set_school!, only: [ :index ]
+  before_action :set_teacher!, only: [ :destroy ]
+  before_action :ensure_not_admin_deletion, only: [ :destroy ]
 
   def index
     result = Teachers::IndexQuery.call(current_user, school: @school)
     render json: Teachers::IndexPresenter.new(result).as_json, status: :ok
+  end
+  # DELETE /api/v1/teachers/:id
+  def destroy
+    if @teacher.destroy
+      # 成功時は204 No Contentを返す
+      head :no_content
+    else
+      # 422 エラー
+      render json: {
+               error: I18n.t("teachers.errors.delete.failure")
+             },
+             status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def set_teacher!
+    @teacher = User.find(params[:id])
+  end
+
+  # 誤ってadminを削除できないようにする
+  def ensure_not_admin_deletion
+    if @teacher.admin_role?
+      render json: {
+               error: I18n.t("teachers.errors.delete.admin")
+             },
+             status: :forbidden
+    end
   end
 end

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -62,6 +62,11 @@ ja:
       generate_token_failed: トークンの作成に失敗しました。
       unexpected: 予期せぬエラーが発生しました
       invalid: この招待リンクは無効か期限切れです。
+  teachers:
+    errors:
+      delete:
+        admin: 管理者は削除できません。
+        failure: 講師の削除に失敗しました。
 
   devise:
     confirmations:

--- a/spec/requests/api/v1/teachers_spec.rb
+++ b/spec/requests/api/v1/teachers_spec.rb
@@ -177,4 +177,42 @@ RSpec.describe "Api::V1::Teachers", type: :request do
       end
     end
   end
+
+  describe "DELETE /destroy" do
+    let!(:school) { create(:school) }
+    let(:teacher) { create(:user, school: school) }
+    let(:user) { create(:user, school: school) }
+
+    context "admin signed in" do
+      before { user.role = :admin }
+      it "deletes a teacher and returns no content (204)" do
+        teacher.role = :teacher
+        delete_with_auth(api_v1_teacher_path(teacher), user)
+        expect(response).to have_http_status(:no_content)
+        expect(User.exists?(teacher.id)).to be_falsey
+      end
+
+      it "does not delete admin" do
+        teacher.update!(role: :admin)
+        delete_with_auth(api_v1_teacher_path(teacher), user)
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to include("管理者は削除できません")
+        expect(teacher.reload).to be_present
+      end
+    end
+    context "teacher signed in" do
+      before { user.role = :teacher }
+      it "returns Forbidden response (403)" do
+        delete_with_auth(api_v1_teacher_path(teacher), user)
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to include("講師はこの操作を行うことができません")
+      end
+    end
+    context "unauthenticated user" do
+      it "returns  an unauthorized response (401)" do
+        delete api_v1_teacher_path(teacher)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## ISSUE

close #49

## 実装概要

<!-- この PR の目的・背景を 1～2 行で記載してください（例：バグ修正、UI改善、パフォーマンス向上など） -->
- **Teachersコントローラーの`destroy`アクションを実装**
  - 管理者が講師を削除できる機能を追加
  - 管理者自身（`admin`ロール）の削除を禁止
  - 削除成功時は`204 No Content`を返却
  - 削除失敗時は`422 Unprocessable Entity`を返却

- **エラーメッセージのI18n対応**
  - `teachers.errors.delete.admin`: 管理者削除禁止メッセージ
  - `teachers.errors.delete.failure`: 削除失敗時のメッセージ

- **リクエストスペックの追加**
  - 管理者が講師を削除できることを確認
  - 管理者自身（`admin`ロール）は削除できないことを確認
  - 権限のない講師が削除を試みた場合に`403 Forbidden`を返すことを確認
  - 未認証ユーザーが削除を試みた場合に`401 Unauthorized`を返すことを確認

## スクリーンショット

<!-- 変更前後のスクリーンショットやGIFを貼ってください。なければ省略可能です -->

## 動作確認手順

<!-- レビュアーが確認しやすいように、操作手順を具体的に記載してください -->

1. 管理者でログインし、講師を削除できることを確認
2. 管理者自身（`admin`ロール）の削除が禁止されていることを確認
3. 権限のない講師が削除を試みた場合に`403 Forbidden`が返ることを確認
4. 未認証ユーザーが削除を試みた場合に`401 Unauthorized`が返ることを確認

## 影響範囲

- `Api::V1::TeachersController`の`destroy`アクション
- I18nロケールファイル（`devise.views.ja.yml`）
- リクエストスペック（`teachers_spec.rb`）

## レビューポイント

- [ ] 管理者が講師を削除できるか
- [ ] 管理者自身（`admin`ロール）の削除が禁止されているか
- [ ] 権限のないユーザーや未認証ユーザーが適切なエラーレスポンスを受け取るか
- [ ] エラーメッセージがI18n対応されているか

## デプロイ／運用

- **マイグレーション**：無
- **環境変数の追加**：無
- **破壊的変更の有無**：無

## チェックリスト（作成者用）

- [x] 自身で動作確認・コードレビューを完了した
- [x] 不要なコメント・デバッグコードを削除した
- [x] コミットメッセージがわかりやすく記述されている
- [x] 関連 Issue がリンクされている（あれば）

## チェックリスト（レビュアー用）

- [ ] 命名が一貫性をもち、一貫性があるか
- [ ] 処理が重複していないか
- [ ] コントローラーが肥大化していないか
- [ ] テストがあり、目的をカバーしているか
- [ ] UX や画面に不自然さがないか
