### PR TITLE
techers controller のupdate アクションの作成とdestroy アクションの修正

### DIFF
--- a/app/controllers/api/v1/invites_controller.rb
+++ b/app/controllers/api/v1/invites_controller.rb
@@ -11,12 +11,6 @@ class Api::V1::InvitesController < ApplicationController
   rescue Invites::InvalidInviteError => e
     # 404 エラー
     render json: { message: e.message }, status: :not_found
-  rescue StandardError => e
-    # 予期せぬエラー 500
-    render json: {
-             message: I18n.t("invites.errors.unexpected")
-           },
-           status: :internal_server_error
   end
 
   # POST /api/v1/invites
@@ -26,11 +20,5 @@ class Api::V1::InvitesController < ApplicationController
   rescue Invites::TokenGenerateError => e
     # 422 エラー
     render json: { message: e.message }, status: :unprocessable_content
-  rescue StandardError => e
-    # 予期せぬエラー 500
-    render json: {
-             message: I18n.t("invites.errors.unexpected")
-           },
-           status: :internal_server_error
   end
 end

--- a/app/controllers/api/v1/teachers_controller.rb
+++ b/app/controllers/api/v1/teachers_controller.rb
@@ -12,30 +12,14 @@ class Api::V1::TeachersController < ApplicationController
   # PATCH /api/v1/teachers/:id
   def update
     teacher = User.find(params[:id])
+    result = Teachers::Updater.call(teacher:, attrs: update_params)
 
-    base_attrs, subject_ids, day_ids, student_ids =
-      extract_update_payload(update_params)
-
-    ActiveRecord::Base.transaction do
-      teacher.update!(base_attrs) unless base_attrs.empty?
-
-      # 多対多: 差し替え（空配列なら全解除）
-      teacher.class_subject_ids = subject_ids if subject_ids
-      teacher.available_day_ids = day_ids if day_ids
-      teacher.student_ids = student_ids if student_ids
+    if result.ok?
+      render json: { teacher_id: result.teacher.id }, status: :ok
+    else
+      # errors は配列
+      render json: { errors: result.errors }, status: :unprocessable_content
     end
-
-    render json: { teacher_id: teacher.reload.id }, status: :ok
-  rescue ActiveRecord::RecordNotFound
-    render json: {
-             error: I18n.t("teachers.errors.not_found")
-           },
-           status: :not_found
-  rescue ActiveRecord::RecordInvalid => e
-    render json: {
-             error: e.record.errors.full_messages
-           },
-           status: :unprocessable_content
   end
 
   # DELETE /api/v1/teachers/:id
@@ -68,13 +52,5 @@ class Api::V1::TeachersController < ApplicationController
       available_day_ids: [],
       student_ids: []
     )
-  end
-
-  def extract_update_payload(p)
-    base = p.slice(:name, :employment_status).compact_blank
-    subject_ids = p[:subject_ids]
-    day_ids = p[:available_day_ids]
-    student_ids = p[:student_ids]
-    [ base, subject_ids, day_ids, student_ids ]
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::API
   before_action { I18n.locale = :ja }
+  rescue_from StandardError, with: :render_internal_error
   include DeviseTokenAuth::Concerns::SetUserByToken
   include DeviseHackFakeSession
 
@@ -47,5 +48,17 @@ class ApplicationController < ActionController::API
              status: :forbidden
       nil
     end
+  end
+
+  def render_internal_error(exception)
+    # ログにエラーを記録
+    Rails.logger.error(exception.message)
+    Rails.logger.error(exception.backtrace.join("\n"))
+
+    # 500 Internal Server Errorを返す
+    render json: {
+             error: I18n.t("application.errors.internal_server_error")
+           },
+           status: :internal_server_error
   end
 end

--- a/app/services/teachers/updater.rb
+++ b/app/services/teachers/updater.rb
@@ -37,11 +37,15 @@ module Teachers
       # 空の値は更新しない
       base = p.slice(:name, :employment_status).compact_blank
       # 配列の値は重複とnilを除去し、空の配列はそのまま返す
-      subject_ids = Array(p[:subject_ids]).compact.uniq
-      day_ids = Array(p[:available_day_ids]).compact.uniq
-      student_ids = Array(p[:student_ids]).compact.uniq
+      subject_ids = extract_ids(p[:subject_ids])
+      day_ids = extract_ids(p[:available_day_ids])
+      student_ids = extract_ids(p[:student_ids])
       # subject_ids, day_ids, student_ids が空の場合は nil を返す
       [ base, subject_ids.presence, day_ids.presence, student_ids.presence ]
+    end
+
+    def extract_ids(val)
+      Array(val).compact.uniq
     end
   end
 end

--- a/app/services/teachers/updater.rb
+++ b/app/services/teachers/updater.rb
@@ -1,0 +1,47 @@
+module Teachers
+  class Updater
+    # errors は配列で返す
+    Result = Data.define(:ok?, :teacher, :errors)
+
+    def self.call(teacher:, attrs:)
+      new(teacher, attrs).call
+    end
+
+    def initialize(teacher, attrs)
+      @teacher = teacher
+      @raw = attrs
+    end
+
+    def call
+      base, subject_ids, day_ids, student_ids = extract(@raw)
+
+      # 更新操作
+      ActiveRecord::Base.transaction do
+        @teacher.update!(base)
+        @teacher.class_subject_ids = subject_ids if subject_ids
+        @teacher.available_day_ids = day_ids if day_ids
+        @teacher.student_ids = student_ids if student_ids
+      end
+
+      # 成功時の結果を返す
+      Result.new(true, @teacher.reload, [])
+    rescue ActiveRecord::RecordInvalid => e
+      Result.new(false, @teacher, e.record.errors.full_messages)
+    rescue ArgumentError => e # enum無効値など
+      Result.new(false, @teacher, [ I18n.t("teachers.errors.invalid_argument") ])
+    end
+
+    private
+
+    def extract(p)
+      # 空の値は更新しない
+      base = p.slice(:name, :employment_status).compact_blank
+      # 配列の値は重複とnilを除去し、空の配列はそのまま返す
+      subject_ids = Array(p[:subject_ids]).compact.uniq
+      day_ids = Array(p[:available_day_ids]).compact.uniq
+      student_ids = Array(p[:student_ids]).compact.uniq
+      # subject_ids, day_ids, student_ids が空の場合は nil を返す
+      [ base, subject_ids.presence, day_ids.presence, student_ids.presence ]
+    end
+  end
+end

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -28,6 +28,7 @@ ja:
         school_code: 学校コード
         name: 名前
         role: 権限
+        employment_status: 雇用状況
 
       school:
         name: 学校名
@@ -52,10 +53,13 @@ ja:
               blank: を入力してください
             school_code:
               invalid: が無効です。
+            name:
+              blank: を入力してください
   application:
     errors:
       not_found_school: 学校が見つかりませんでした。
       teacher_unable_operate: 講師はこの操作を行うことができません。
+      internal_server_error: サーバー内部でエラーが発生しました。しばらくしてから再度お試しください。
 
   invites:
     errors:
@@ -69,6 +73,7 @@ ja:
         admin: 管理者は削除できません。
         failure: 講師の削除に失敗しました。
       not_found: ユーザーが見つかりませんでした。
+      invalid_argument: 無効な引数が指定されました。
 
   devise:
     confirmations:

--- a/spec/services/teachers/updater_spec.rb
+++ b/spec/services/teachers/updater_spec.rb
@@ -1,0 +1,119 @@
+RSpec.describe Teachers::Updater do
+  describe ".call" do
+    subject(:call) { described_class.call(teacher: teacher, attrs: attrs) }
+    # 必要な科目、曜日、生徒を定義しておく
+    let!(:subjects) do
+      %i[english japanese mathematics].each_with_index.map do |trait, i|
+        create(:class_subject, trait, id: i + 1)
+      end
+    end
+    let!(:available_days) do
+      %i[sunday monday tuesday].each_with_index.map do |trait, i|
+        create(:available_day, trait, id: i + 1)
+      end
+    end
+    let!(:students) { (1..3).map { |i| create(:student, id: i) } }
+
+    context "with valid attributes" do
+      let(:teacher) { create(:user, :teacher) }
+      let(:attrs) do
+        {
+          name: "New Name",
+          employment_status: "active",
+          subject_ids: [ 1, 2, 3 ],
+          available_day_ids: [ 1, 2, 3 ],
+          student_ids: [ 1, 2, 3 ]
+        }
+      end
+
+      it "updates the teacher's attributes and returns a successful result" do
+        # 前のteacher の情報を入れておく
+        teacher.name = "name"
+        teacher.employment_status = "inactive"
+        teacher.class_subject_ids = []
+        teacher.available_day_ids = []
+        teacher.student_ids = []
+        teacher.save!
+
+        # updater を呼んで更新されることを確認
+        result = call
+        expect(result).to be_ok
+        expect(teacher.reload.name).to eq("New Name")
+        expect(teacher.reload.employment_status).to eq("active")
+        expect(teacher.reload.class_subject_ids).to eq([ 1, 2, 3 ])
+        expect(teacher.reload.available_day_ids).to eq([ 1, 2, 3 ])
+        expect(teacher.reload.student_ids).to eq([ 1, 2, 3 ])
+      end
+    end
+
+    context "when arrays are provided (dedupe works)" do
+      let(:teacher) { create(:user, :teacher) }
+      let(:attrs) do
+        {
+          name: "ok",
+          employment_status: "active",
+          subject_ids: [ 1, 1, 2 ],
+          available_day_ids: [ 2, 2, 3 ],
+          student_ids: [ 1, 1, 3 ]
+        }
+      end
+
+      it "sets associations with uniq" do
+        result = call
+        expect(result.ok?).to be true
+        expect(teacher.reload.class_subject_ids).to eq([ 1, 2 ])
+        expect(teacher.reload.available_day_ids).to eq([ 2, 3 ])
+        expect(teacher.reload.student_ids).to eq([ 1, 3 ])
+      end
+    end
+
+    context "when arrays are empty (skip-update spec)" do
+      let(:teacher) do
+        create(
+          :user,
+          :teacher,
+          class_subject_ids: [ 1 ],
+          available_day_ids: [ 1 ],
+          student_ids: [ 1 ]
+        )
+      end
+      let(:attrs) do
+        {
+          name: "ok",
+          employment_status: "active",
+          subject_ids: [], # extract の .presence で nil になり、代入をスキップ
+          available_day_ids: [],
+          student_ids: []
+        }
+      end
+
+      it "does not touch associations" do
+        result = call
+        expect(result).to be_ok
+        expect(teacher.reload.class_subject_ids).to eq([ 1 ])
+        expect(teacher.reload.available_day_ids).to eq([ 1 ])
+        expect(teacher.reload.student_ids).to eq([ 1 ])
+      end
+    end
+    context "returns ArgumentError if invalid enum values are provided" do
+      let(:teacher) { create(:user, :teacher) }
+      let(:attrs) do
+        {
+          name: "ok",
+          employment_status: "invalid_status", # Invalid enum value
+          subject_ids: [ 1, 2 ],
+          available_day_ids: [ 1, 2 ],
+          student_ids: [ 1, 2 ]
+        }
+      end
+
+      it "returns an error result" do
+        result = call
+        expect(result.ok?).to be false
+        expect(result.errors).to include(
+          I18n.t("teachers.errors.invalid_argument")
+        )
+      end
+    end
+  end
+end

--- a/spec/services/teachers/updater_spec.rb
+++ b/spec/services/teachers/updater_spec.rb
@@ -15,7 +15,17 @@ RSpec.describe Teachers::Updater do
     let!(:students) { (1..3).map { |i| create(:student, id: i) } }
 
     context "with valid attributes" do
-      let(:teacher) { create(:user, :teacher) }
+      let!(:teacher) do
+        create(
+          :user,
+          :teacher,
+          name: "Old Name",
+          employment_status: "inactive",
+          class_subject_ids: [],
+          available_day_ids: [],
+          student_ids: []
+        )
+      end
       let(:attrs) do
         {
           name: "New Name",
@@ -27,14 +37,6 @@ RSpec.describe Teachers::Updater do
       end
 
       it "updates the teacher's attributes and returns a successful result" do
-        # 前のteacher の情報を入れておく
-        teacher.name = "name"
-        teacher.employment_status = "inactive"
-        teacher.class_subject_ids = []
-        teacher.available_day_ids = []
-        teacher.student_ids = []
-        teacher.save!
-
         # updater を呼んで更新されることを確認
         result = call
         expect(result).to be_ok


### PR DESCRIPTION
## ISSUE

close #53

## 実装概要

- **Teachersコントローラーの`update`アクションをリファクタリング**
  - `Teachers::Updater`サービスオブジェクトを導入し、更新処理を切り出し
  - `name`, `employment_status`などの基本属性と、`subject_ids`, `available_day_ids`, `student_ids`の多対多関連を一括更新
  - トランザクションを使用してデータ整合性を確保
  - 更新成功時は`teacher_id`を返却、失敗時はエラーメッセージを返却

- **Teachersコントローラーの`destroy`アクションを修正**
  - 削除失敗時に`422 Unprocessable Entity`を返却する処理を追加
  - 削除成功時は`204 No Content`を返却

- **ApplicationControllerに共通エラーハンドリングを追加**
  - `rescue_from StandardError`を追加し、予期しないエラーを一元管理
  - ログにエラーを記録し、`500 Internal Server Error`を返却

- **I18nエラーメッセージの追加**
  - `teachers.errors.invalid_argument`: 無効な引数が指定された場合のエラーメッセージ
  - `application.errors.internal_server_error`: サーバー内部エラーのメッセージ

- **テストの追加・修正**
  - `Teachers::Updater`の単体テストを追加
    - 正常系: 属性・関連の更新が正しく行われることを確認
    - 異常系: 無効な値や空配列が渡された場合の挙動を確認
  - `teachers_spec.rb`に`update`および`destroy`アクションのリクエストスペックを追加
    - 正常系: 更新・削除が成功することを確認
    - 異常系: 無効な値や存在しないIDが指定された場合のエラーハンドリングを確認

## スクリーンショット

<!-- 必要に応じてAPIレスポンス例やテスト結果キャプチャを貼付 -->

## 動作確認手順

1. `PATCH /api/v1/teachers/:id`に対して有効なデータを送信し、講師情報が正しく更新されることを確認
2. 無効なデータを送信した場合に適切なエラーメッセージが返ることを確認
3. `DELETE /api/v1/teachers/:id`で講師が正しく削除されることを確認
4. 削除失敗時に`422 Unprocessable Entity`が返ることを確認

## 影響範囲

- Teachersコントローラー
- Teachers::Updaterサービスオブジェクト
- ApplicationControllerのエラーハンドリング
- テストコード全般

## レビューポイント

- [ ] `update`アクションの処理が正しくリファクタリングされているか
- [ ] `destroy`アクションのエラーハンドリングが適切か
- [ ] `Teachers::Updater`の処理が正確かつ効率的か
- [ ] テストが網羅的かつ正確か

## デプロイ／運用

- **マイグレーション**：無
- **環境変数の追加**：無
- **破壊的変更の有無**：無

## チェックリスト（作成者用）

- [x] 自身で動作確認・コードレビューを完了した
- [x] 不要なコメント・デバッグコードを削除した
- [x] コミットメッセージがわかりやすく記述されている
- [x] 関連 Issue がリンクされている（あれば）

## チェックリスト（レビュアー用）

- [ ] 命名が一貫性をもち、一貫性があるか
- [ ] 処理が重複していないか
- [ ] コントローラーが肥大化していないか
- [ ] テストがあり、目的をカバーしているか
- [ ] UX や画面に不自然さがないか

