### PR TITLE
lessonNote のdestroy アクションテスト追加

### DIFF
--- a/spec/requests/api/v1/lesson_notes_spec.rb
+++ b/spec/requests/api/v1/lesson_notes_spec.rb
@@ -396,4 +396,74 @@ RSpec.describe "Api::V1::LessonNotes", type: :request do
       end
     end
   end
+  describe "DELETE /destroy" do
+    let!(:lesson_note) do
+      create(
+        :lesson_note,
+        student_class_subject: student_class_subject,
+        created_by: admin_user,
+        created_by_name: admin_user.name
+      )
+    end
+
+    let!(:other_lesson_note) do
+      create(
+        :lesson_note,
+        student_class_subject: other_student_class_subject,
+        created_by: other_admin_user,
+        created_by_name: other_admin_user.name
+      )
+    end
+
+    context "an authenticated admin user" do
+      it "deletes the lesson note" do
+        delete_with_auth(
+          api_v1_lesson_note_path(lesson_note),
+          admin_user,
+          params: {
+            student_id: student.id
+          }
+        )
+        expect(response).to have_http_status(:no_content)
+        expect(LessonNote.exists?(lesson_note.id)).to be_falsey
+      end
+      it "returns bad request when student_id is missing" do
+        delete_with_auth(
+          api_v1_lesson_note_path(lesson_note),
+          admin_user,
+          params: {
+            student_id: "invalid_student_id"
+          }
+        )
+        expect(response).to have_http_status(:bad_request)
+        expect(LessonNote.exists?(lesson_note.id)).to be_truthy
+      end
+      it "returns 404 when deleting a lesson note from another school" do
+        delete_with_auth(
+          api_v1_lesson_note_path(other_lesson_note),
+          admin_user,
+          params: {
+            student_id: other_student.id
+          }
+        )
+        expect(response).to have_http_status(:not_found)
+        expect(LessonNote.exists?(other_lesson_note.id)).to be_truthy
+      end
+    end
+
+    context "an authenticated teacher" do
+      it "does not delete the lesson note" do
+        delete_with_auth(api_v1_lesson_note_path(lesson_note), teacher)
+        expect(response).to have_http_status(:forbidden)
+        expect(LessonNote.exists?(lesson_note.id)).to be_truthy
+      end
+    end
+
+    context "an unauthenticated user" do
+      it "returns 401 Unauthorized" do
+        delete api_v1_lesson_note_path(lesson_note)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## ISSUE

close #110 

## 実装概要

<!-- この PR の目的・背景を 1～2 行で記載してください（例：バグ修正、UI改善、パフォーマンス向上など） -->
LessonNote の destroy アクションに対するリクエストスペックを追加し、以下のケースを網羅:

- 管理者が正しく削除できる（204）
- student_id 不正時に 400 Bad Request
- 他校レコード削除試行で 404 Not Found
- 教師は削除不可（403）
- 未認証ユーザーは 401


## 影響範囲

## <!-- この変更が影響する画面・機能・ファイルなどを記載してください（例：todo一覧画面、Userモデルなど） -->
- テストコードのみ

## レビューポイント

<!-- レビュアーに特に見てほしい点があればチェックを入れてください -->

- [ ] **機能**：仕様どおりに動作するか
- [ ] **コード品質**：可読性・保守性
- [ ] **セキュリティ**：権限・バリデーション・入力チェック
- [ ] **パフォーマンス**：処理速度やリソース使用量
- [ ] **CI**：GitHub Actions のワークフローが成功しているか

## デプロイ／運用

<!-- 該当する項目にチェックを入れて、必要に応じて補足してください -->

- **マイグレーション**：無
- **環境変数の追加**：無
- **破壊的変更の有無**：無

## チェックリスト（作成者用）

<!-- PR作成前に確認した内容にチェックを入れてください -->

- [ ] 自身で動作確認・コードレビューを完了した
- [ ] 不要なコメント・デバッグコードを削除した
- [ ] コミットメッセージがわかりやすく記述されている
- [ ] 関連 Issue がリンクされている（あれば）

## チェックリスト（レビュアー用）

- [ ] 命名が一貫性をもち、一貫性があるか
- [ ] 処理が重複していないか
- [ ] コントローラーが肥大化していないか
- [ ] テストがあり、目的をカバーしているか
- [ ] UX や画面に不自然さがないか
